### PR TITLE
use the same actions for the newly scheduled build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/requeuejob/RequeueJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/requeuejob/RequeueJobProperty.java
@@ -36,7 +36,8 @@ public class RequeueJobProperty extends JobProperty<AbstractProject<?, ?>> {
     		if(comp.isOffline())
     		{
     			// If the current computer is offline
-    			Queue.getInstance().schedule(build.getProject());
+    			// Schedule a new build with the same actions
+    			Queue.getInstance().schedule(build.getProject(), 0, build.getActions());
     			return true;
     		}
 


### PR DESCRIPTION
This patch makes this plugin work for jobs which do require actions (e.g. a parameter action). One example if the GitHub pull request build plugin. Without this patch a rescheduled build is always failing since it lacks all the parameters of the original build.

I deployed the patched plugin on our Jenkins with the following result:
- With plugin version 1.0
  - http://build.ros.org/view/Kpr/job/Kpr__genpy__ubuntu_xenial_amd64/33/
  - disconnect slave
  - requeued job fails as expected http://build.ros.org/view/Kpr/job/Kpr__genpy__ubuntu_xenial_amd64/34/
- With modified version 1.1-SNAPSHOT
  - http://build.ros.org/view/Kpr/job/Kpr__genpy__ubuntu_xenial_amd64/35/
  - disconnect slave
  - requeued job works correctly since it received the same parameters http://build.ros.org/view/Kpr/job/Kpr__genpy__ubuntu_xenial_amd64/36/
